### PR TITLE
Cherrypick [AIRFLOW-1166] and [AIRFLOW-790] fixes

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -35,7 +35,8 @@ import time
 from time import sleep
 
 import psutil
-from sqlalchemy import Column, Integer, String, DateTime, func, Index, or_
+from sqlalchemy import Column, Integer, String, DateTime, func, Index, or_, and_
+from sqlalchemy import update
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm.session import make_transient
 from tabulate import tabulate
@@ -928,45 +929,42 @@ class SchedulerJob(BaseJob):
         simple_dag_bag and with states in the old_state will be examined
         :type simple_dag_bag: SimpleDagBag
         """
+        tis_changed = 0
+        if self.using_sqlite:
+            tis_to_change = (
+                session
+                    .query(models.TaskInstance)
+                    .filter(models.TaskInstance.dag_id.in_(simple_dag_bag.dag_ids))
+                    .filter(models.TaskInstance.state.in_(old_states))
+                    .filter(and_(
+                        models.DagRun.dag_id == models.TaskInstance.dag_id,
+                        models.DagRun.execution_date == models.TaskInstance.execution_date,
+                        models.DagRun.state != State.RUNNING))
+                    .with_for_update()
+                    .all()
+            )
+            for ti in tis_to_change:
+                ti.set_state(new_state, session=session)
+                tis_changed += 1
+        else:
+            tis_changed = (
+                session
+                    .query(models.TaskInstance)
+                    .filter(models.TaskInstance.dag_id.in_(simple_dag_bag.dag_ids))
+                    .filter(models.TaskInstance.state.in_(old_states))
+                    .filter(and_(
+                        models.DagRun.dag_id == models.TaskInstance.dag_id,
+                        models.DagRun.execution_date == models.TaskInstance.execution_date,
+                        models.DagRun.state != State.RUNNING))
+                    .update({models.TaskInstance.state: new_state},
+                            synchronize_session=False)
+            )
+            session.commit()
 
-        task_instances_to_change = (
-            session
-            .query(models.TaskInstance)
-            .filter(models.TaskInstance.dag_id.in_(simple_dag_bag.dag_ids))
-            .filter(models.TaskInstance.state.in_(old_states))
-            .with_for_update()
-            .all()
-        )
-        """:type: list[TaskInstance]"""
-
-        for task_instance in task_instances_to_change:
-            dag_runs = DagRun.find(dag_id=task_instance.dag_id,
-                                   execution_date=task_instance.execution_date,
-                                   )
-
-            if len(dag_runs) == 0:
-                self.logger.warn("DagRun for %s %s does not exist",
-                                 task_instance.dag_id,
-                                 task_instance.execution_date)
-                continue
-
-            # There should only be one DAG run. Add some logging info if this
-            # is not the case for later debugging.
-            if len(dag_runs) > 1:
-                self.logger.warn("Multiple DagRuns found for {} {}: {}"
-                                 .format(task_instance.dag_id,
-                                         task_instance.execution_date,
-                                         dag_runs))
-
-            if not any(dag_run.state == State.RUNNING for dag_run in dag_runs):
-                self.logger.warn("Setting {} to state={} as it does not have "
-                                 "a DagRun in the {} state"
-                                 .format(task_instance,
-                                         new_state,
-                                         State.RUNNING))
-                task_instance.state = new_state
-                session.merge(task_instance)
-        session.commit()
+        if tis_changed > 0:
+            self.logger.warning("Set {} task instances to state={} as their associated "
+                                "DagRun was not in RUNNING state".format(
+                tis_changed, new_state))
 
     @provide_session
     def _execute_task_instances(self,

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -918,8 +918,9 @@ class SchedulerJob(BaseJob):
         """
         For all DAG IDs in the SimpleDagBag, look for task instances in the
         old_states and set them to new_state if the corresponding DagRun
-        exists but is not in the running state. This normally should not
-        happen, but it can if the state of DagRuns are changed manually.
+        does not exist or exists but is not in the running state. This
+        normally should not happen, but it can if the state of DagRuns are
+        changed manually.
 
         :param old_states: examine TaskInstances in this state
         :type old_state: list[State]
@@ -930,35 +931,33 @@ class SchedulerJob(BaseJob):
         :type simple_dag_bag: SimpleDagBag
         """
         tis_changed = 0
+        query = session \
+            .query(models.TaskInstance) \
+            .outerjoin(models.DagRun, and_(
+                models.TaskInstance.dag_id == models.DagRun.dag_id,
+                models.TaskInstance.execution_date == models.DagRun.execution_date)) \
+            .filter(models.TaskInstance.dag_id.in_(simple_dag_bag.dag_ids)) \
+            .filter(models.TaskInstance.state.in_(old_states)) \
+            .filter(or_(
+                models.DagRun.state != State.RUNNING,
+                models.DagRun.state.is_(None)))
         if self.using_sqlite:
-            tis_to_change = (
-                session
-                    .query(models.TaskInstance)
-                    .filter(models.TaskInstance.dag_id.in_(simple_dag_bag.dag_ids))
-                    .filter(models.TaskInstance.state.in_(old_states))
-                    .filter(and_(
-                        models.DagRun.dag_id == models.TaskInstance.dag_id,
-                        models.DagRun.execution_date == models.TaskInstance.execution_date,
-                        models.DagRun.state != State.RUNNING))
-                    .with_for_update()
-                    .all()
-            )
+            tis_to_change = query \
+                .with_for_update() \
+                .all()
             for ti in tis_to_change:
                 ti.set_state(new_state, session=session)
                 tis_changed += 1
         else:
-            tis_changed = (
-                session
-                    .query(models.TaskInstance)
-                    .filter(models.TaskInstance.dag_id.in_(simple_dag_bag.dag_ids))
-                    .filter(models.TaskInstance.state.in_(old_states))
-                    .filter(and_(
-                        models.DagRun.dag_id == models.TaskInstance.dag_id,
-                        models.DagRun.execution_date == models.TaskInstance.execution_date,
-                        models.DagRun.state != State.RUNNING))
-                    .update({models.TaskInstance.state: new_state},
-                            synchronize_session=False)
-            )
+            subq = query.subquery()
+            tis_changed = session \
+                .query(models.TaskInstance) \
+                .filter(and_(
+                    models.TaskInstance.dag_id == subq.c.dag_id,
+                    models.TaskInstance.execution_date ==
+                    subq.c.execution_date)) \
+                .update({models.TaskInstance.state: new_state},
+                        synchronize_session=False)
             session.commit()
 
         if tis_changed > 0:

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -612,6 +612,77 @@ class SchedulerJobTest(unittest.TestCase):
 
         session.close()
 
+    def test_change_state_for_tis_without_dagrun(self):
+        dag = DAG(
+            dag_id='test_change_state_for_tis_without_dagrun',
+            start_date=DEFAULT_DATE)
+
+        DummyOperator(
+            task_id='dummy',
+            dag=dag,
+            owner='airflow')
+
+        dag2 = DAG(
+            dag_id='test_change_state_for_tis_without_dagrun_dont_change',
+            start_date=DEFAULT_DATE)
+
+        DummyOperator(
+            task_id='dummy',
+            dag=dag2,
+            owner='airflow')
+
+        session = settings.Session()
+        dr = dag.create_dagrun(run_id=DagRun.ID_PREFIX,
+                               state=State.RUNNING,
+                               execution_date=DEFAULT_DATE,
+                               start_date=DEFAULT_DATE,
+                               session=session)
+
+        dr2 = dag2.create_dagrun(run_id=DagRun.ID_PREFIX,
+                                 state=State.RUNNING,
+                                 execution_date=DEFAULT_DATE,
+                                 start_date=DEFAULT_DATE,
+                                 session=session)
+
+        ti = dr.get_task_instance(task_id='dummy', session=session)
+        ti.state = State.SCHEDULED
+        session.commit()
+
+        ti2 = dr2.get_task_instance(task_id='dummy', session=session)
+        ti2.state = State.SCHEDULED
+        session.commit()
+
+        dagbag = SimpleDagBag([dag])
+        scheduler = SchedulerJob(num_runs=0, run_duration=0)
+        scheduler._change_state_for_tis_without_dagrun(simple_dag_bag=dagbag,
+                                                       old_states=[State.SCHEDULED, State.QUEUED],
+                                                       new_state=State.NONE,
+                                                       session=session)
+
+        ti.refresh_from_db(session=session)
+        self.assertEqual(ti.state, State.SCHEDULED)
+
+        ti2.refresh_from_db(session=session)
+        self.assertEqual(ti2.state, State.SCHEDULED)
+
+        dr.refresh_from_db(session=session)
+        dr.state = State.FAILED
+
+        # why o why
+        session.merge(dr)
+        session.commit()
+
+        scheduler._change_state_for_tis_without_dagrun(simple_dag_bag=dagbag,
+                                                       old_states=[State.SCHEDULED, State.QUEUED],
+                                                       new_state=State.NONE,
+                                                       session=session)
+        ti.refresh_from_db(session=session)
+        self.assertEqual(ti.state, State.NONE)
+
+        # don't touch ti2
+        ti2.refresh_from_db(session=session)
+        self.assertEqual(ti2.state, State.SCHEDULED)
+
     def test_execute_helper_reset_orphaned_tasks(self):
         session = settings.Session()
         dag = DAG(


### PR DESCRIPTION
Cherry-pick fixes into clover branch:

[AIRFLOW-1166] Speed up _change_state_for_tis_without_dagrun
https://github.com/apache/incubator-airflow/pull/2267

[AIRFLOW-790] Clean up TaskInstances without DagRuns
https://github.com/apache/incubator-airflow/pull/2267
