### PR TITLE
[DO NOT MERGE] Don't disable existing loggers during alembic migrations

### DIFF
--- a/airflow/migrations/env.py
+++ b/airflow/migrations/env.py
@@ -25,7 +25,7 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-fileConfig(config.config_file_name)
+fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # add your model's MetaData object here
 # for 'autogenerate' support


### PR DESCRIPTION
Python's `logging.fileConfig` function has a default argument `disable_existing_loggers=True`, which this PR changes to False. The reason this is useful for us is that this line of code ends up being called in our test suites when we call `airflow.utils.db.resetdb`, and since this disables all loggers any use of logging afterwards in the test suite is affected.

We discovered this trying to use pytest's [`caplog`](https://docs.pytest.org/en/latest/logging.html#caplog-fixture) feature, which was unable to capture any logs when `resetdb` had been called before the test using `caplog`.

Below is an example minimal test that illustrates the problem. With this change the test will pass, without this change the test will fail.

```
import logging

import pytest

import airflow.utils.db as af_db

LOGGER = logging.getLogger(__name__)

@pytest.fixture(autouse=True)
def resetdb():
    af_db.resetdb()

def test_caplog(caplog):
    LOGGER.info('LINE 1')
    assert caplog.record_tuples
    assert 'LINE 1' in caplog.text
```