### PR TITLE
[ENGSUP-3401][AIRFLOW-2466] consider task_id in _change_state_for_tis_without_dagrun

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -954,6 +954,7 @@ class SchedulerJob(BaseJob):
                 .query(models.TaskInstance) \
                 .filter(and_(
                     models.TaskInstance.dag_id == subq.c.dag_id,
+                    models.TaskInstance.task_id == subq.c.task_id,
                     models.TaskInstance.execution_date ==
                     subq.c.execution_date)) \
                 .update({models.TaskInstance.state: new_state},


### PR DESCRIPTION
Cherry-pick fix https://github.com/apache/incubator-airflow/pull/3360 into CloverHealth airflow fork.

Test failures are a false positive because old versions of airflow have broken test frameworks for current versions of pip. Tests can be seen passing in the mainline Airflow PR.