### PR TITLE
[DI-32] [AIRFLOW-387] Close SQLAlchemy sessions properly

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from functools import wraps
 import logging
 import os
+import contextlib
 
 from alembic.config import Config
 from alembic import command
@@ -32,6 +33,24 @@ from sqlalchemy.pool import Pool
 from airflow import settings
 
 
+
+@contextlib.contextmanager
+def create_session():
+    """
+    Contextmanager that will create and teardown a session.
+    """
+    session = settings.Session()
+    try:
+        yield session
+        session.expunge_all()
+        session.commit()
+    except:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
 def provide_session(func):
     """
     Function decorator that provides a session if it isn't provided.
@@ -41,21 +60,20 @@ def provide_session(func):
     """
     @wraps(func)
     def wrapper(*args, **kwargs):
-        needs_session = False
         arg_session = 'session'
+
         func_params = func.__code__.co_varnames
         session_in_args = arg_session in func_params and \
             func_params.index(arg_session) < len(args)
-        if not (arg_session in kwargs or session_in_args):
-            needs_session = True
-            session = settings.Session()
-            kwargs[arg_session] = session
-        result = func(*args, **kwargs)
-        if needs_session:
-            session.expunge_all()
-            session.commit()
-            session.close()
-        return result
+        session_in_kwargs = arg_session in kwargs
+
+        if session_in_kwargs or session_in_args:
+            return func(*args, **kwargs)
+        else:
+            with create_session() as session:
+                kwargs[arg_session] = session
+                return func(*args, **kwargs)
+
     return wrapper
 
 


### PR DESCRIPTION
This PR cherry picks updates to the `provide_session` helper from [this upstream PR](https://github.com/apache/incubator-airflow/pull/2739), in order to rollback and close SQLAlchemy sessions in error cases. Note that this does not include all changes from the upstream PR; only those changes to the file `airflow/utils/db.py`.